### PR TITLE
Fix for Roundcube 1.1 and added user preference to enable/disable

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ To use the plugin drop the code into Roundcube's plugins-folder and enable it in
     git clone git://github.com/posteo/show_pgp_mime
     vim ../config/config.inc.php
 
+The feature will be enabled for all users if the plugin is activated. You can control
+the default by setting the following option in Roundcube config:
+
+    // display of encrypted pgp/mime content in mail view
+    $config['show_pgp_mime'] = false;
 
 ## Contribution
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To customize the text that prefixes the displayed message-part see localization/
 
 ## Requirements
 
-Only confirmed to be working with Roundcube v1.0.x.
+Confirmed to be working with Roundcube v1.0.x and v1.1.x.
 
 
 ## Install

--- a/localization/de_DE.inc
+++ b/localization/de_DE.inc
@@ -22,6 +22,5 @@
 
 $labels = array();
 $labels['show_pgp_mime_body_prefix'] = 'Dies ist eine mit PGP/MIME verschlüsselte Nachricht. Sie können Sie mit Addons wie Mailvelope entschlüsseln, um sie im Webmailer zu lesen.';
-
-$messages = array();
+$labels['show_pgp_mime_prefs_label'] = 'PGP/MIME Nachrichten anzeigen (verschlüsselt)';
 

--- a/localization/en_US.inc
+++ b/localization/en_US.inc
@@ -22,6 +22,5 @@
 
 $labels = array();
 $labels['show_pgp_mime_body_prefix'] = 'This is a PGP/MIME encrypted message. You can decrypt the message with addons like Mailvelope to read it in our webmail client.';
-
-$messages = array();
+$labels['show_pgp_mime_prefs_label'] = 'Show PGP/MIME messages (encrypted)';
 

--- a/show_pgp_mime.php
+++ b/show_pgp_mime.php
@@ -80,7 +80,7 @@ class show_pgp_mime extends rcube_plugin {
         return $args;
     }
     $rcmail = rcmail::get_instance();
-    $enabled = $rcmail->config->get('show_pgp_mime', 'foo');
+    $enabled = $rcmail->config->get('show_pgp_mime', true);
     $field_id = 'show_pgp_mime';
     $input = new html_checkbox(array('name' => '_'.$field_id, 'id' => $field_id, 'value' => '1'));
 


### PR DESCRIPTION
With Roundcube 1.1 (soon to be released), the plugin doesn't work anymore after some internal message part handling has changed. This PR slightly changes the logic of adding the encrypted content to the UI but works with both versions 1.0 and 1.1.

In addition to that, I added a user preference option (in Displaying Messages > Advanced Options) which allows the feature to be disabled for users who don't have Mailvelope installed. That again can be suppressed by setting

```
$config['dont_override'][] = 'show_pgp_mime';
```
